### PR TITLE
Refactor route engine classes to shared base

### DIFF
--- a/byul_demo/world/route_engine/algo_engine.py
+++ b/byul_demo/world/route_engine/algo_engine.py
@@ -10,35 +10,7 @@ from coord import c_coord
 
 from utils.log_to_panel import g_logger
 
-class RouteRequest:
-    def __init__(self,
-                 map_ptr,
-                 npc_id: str,
-                 type: RouteAlgotype,
-                 start: tuple,
-                 goal: tuple,
-                 on_route_found_cb: Callable,
-                 max_retry: int = 10000,
-                 visited_logging: bool = False,
-                 cost_func: str = "default",
-                 heuristic_func: str = "euclidean",
-                 userdata: any = None):
-        self.map_ptr = map_ptr
-        self.npc_id = npc_id
-        self.type = type
-        self.start = start
-        self.goal = goal
-        self.on_route_found_cb = on_route_found_cb
-        self.max_retry = max_retry
-        self.visited_logging = visited_logging
-        self.cost_func = cost_func
-        self.heuristic_func = heuristic_func
-        self.userdata = userdata
-
-class RouteResult:
-    def __init__(self, npc_id: str, route: 'c_route'):
-        self.npc_id = npc_id
-        self.route = route
+from .base import RouteRequest, RouteResult
 
 class AlgoEngine:
     def __init__(self, max_workers: int = 4):

--- a/byul_demo/world/route_engine/base.py
+++ b/byul_demo/world/route_engine/base.py
@@ -1,0 +1,41 @@
+# Base classes for route engines
+from typing import Callable, Any, Optional
+
+class RouteRequest:
+    """Common request parameters for different route engines."""
+
+    def __init__(self,
+                 map_ptr: Any,
+                 npc_id: str,
+                 start: tuple,
+                 goal: tuple,
+                 on_route_found_cb: Callable,
+                 type: Any = None,
+                 move_cb: Optional[Callable] = None,
+                 interval_msec: int = 100,
+                 max_retry: int = 10000,
+                 visited_logging: bool = False,
+                 cost_func: str = "default",
+                 heuristic_func: str = "euclidean",
+                 userdata: Any = None,
+                 on_real_route_found_cb: Optional[Callable] = None):
+        self.map_ptr = map_ptr
+        self.npc_id = npc_id
+        self.start = start
+        self.goal = goal
+        self.on_route_found_cb = on_route_found_cb
+        self.type = type
+        self.move_cb = move_cb
+        self.interval_msec = interval_msec
+        self.max_retry = max_retry
+        self.visited_logging = visited_logging
+        self.cost_func = cost_func
+        self.heuristic_func = heuristic_func
+        self.userdata = userdata
+        self.on_real_route_found_cb = on_real_route_found_cb
+
+
+class RouteResult:
+    def __init__(self, npc_id: str, route: 'c_route'):
+        self.npc_id = npc_id
+        self.route = route

--- a/byul_demo/world/route_engine/dsl_engine.py
+++ b/byul_demo/world/route_engine/dsl_engine.py
@@ -3,42 +3,12 @@ from queue import Queue
 import threading
 from typing import Callable
 from coord import c_coord
-from route import c_route
 from map import c_map
 from dstar_lite import c_dstar_lite
 from utils.log_to_panel import g_logger
 
-class RouteRequest:
-    def __init__(self,
-                 map_ptr,
-                 npc_id: str,
-                 start: tuple,
-                 goal: tuple,
-                 on_route_found_cb: Callable,
-                 move_cb: Callable,
-                 interval_msec: int = 100,
-                 max_retry: int = 10000,
-                 cost_func: str = "default",
-                 heuristic_func: str = "euclidean",
-                 userdata: any = None,
-                 on_real_route_found_cb: Callable = None):
-        self.map_ptr = map_ptr
-        self.npc_id = npc_id
-        self.start = start
-        self.goal = goal
-        self.on_route_found_cb = on_route_found_cb
-        self.move_cb = move_cb
-        self.interval_msec = interval_msec
-        self.max_retry = max_retry
-        self.cost_func = cost_func
-        self.heuristic_func = heuristic_func
-        self.userdata = userdata
-        self.on_real_route_found_cb = on_real_route_found_cb
+from .base import RouteRequest, RouteResult
 
-class RouteResult:
-    def __init__(self, npc_id: str, route: c_route):
-        self.npc_id = npc_id
-        self.route = route
 
 class DslEngine:
     def __init__(self, max_workers: int = 8):


### PR DESCRIPTION
## Summary
- centralize `RouteRequest` and `RouteResult` in `base.py`
- update `AlgoEngine` and `DslEngine` to import from new base module

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f30841f588327a35ddcc85d7f87d6