### PR TITLE
Refactor NPC animator to non-blocking API

### DIFF
--- a/byul_demo/world/npc/npc_animator_engine.py
+++ b/byul_demo/world/npc/npc_animator_engine.py
@@ -31,7 +31,7 @@ class AnimatorEngine:
             self.executor.submit(self._process_task, task)
 
     def _process_task(self, task):
-        task.npc.animator.step(task.npc, task.world, task.elapsed_sec)
+        task.npc.animator.step(task.elapsed_sec)
 
     def shutdown(self):
         self.running = False


### PR DESCRIPTION
## Summary
- overhaul NPC animation to use `start`/`step` API
- update NPC tick logic for new non-blocking animator
- adjust animator engine for the simplified `step`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68709a658ff48327859450b3c644b8c0