### PR TITLE
Integrate animator engine

### DIFF
--- a/byul_demo/world/npc/npc.py
+++ b/byul_demo/world/npc/npc.py
@@ -256,11 +256,7 @@ class NPC(QObject):
                 self.next_index_changed = False
 
             if self.animator.is_anim_started():
-                arrived = self.animator.step(elapsed_sec)
-                self.on_anim_tick()
-
-                if arrived:
-                    self.on_anim_complete()
+                self.world.animator_engine.submit(self, self.world, elapsed_sec)
             
     def on_anim_tick(self):
         # 애니매이션이 실행중에 내부 루프에서 호출되는 콜백함수이다.

--- a/byul_demo/world/npc/npc_animator_engine.py
+++ b/byul_demo/world/npc/npc_animator_engine.py
@@ -31,7 +31,11 @@ class AnimatorEngine:
             self.executor.submit(self._process_task, task)
 
     def _process_task(self, task):
-        task.npc.animator.step(task.elapsed_sec)
+        arrived = task.npc.animator.step(task.elapsed_sec)
+        if task.npc.animator.is_anim_started() or arrived:
+            task.npc.on_anim_tick()
+        if arrived:
+            task.npc.on_anim_complete()
 
     def shutdown(self):
         self.running = False

--- a/byul_demo/world/world.py
+++ b/byul_demo/world/world.py
@@ -9,6 +9,7 @@ from grid.grid_block_manager import GridBlockManager
 from coord import c_coord
 from map import c_map
 from world.route_engine.algo_engine import AlgoEngine
+from world.npc.npc_animator_engine import AnimatorEngine
 
 from world.npc.npc import NPC
 from world.npc.npc_manager import NPCManager
@@ -42,6 +43,7 @@ class World(QObject):
         # self.map_ptr = self.map.ptr()
 
         self.algo_engine = AlgoEngine()
+        self.animator_engine = AnimatorEngine()
         self.grid_unit_m = grid_unit_m
         self.set_grid_unit_m(grid_unit_m)
 
@@ -94,6 +96,7 @@ class World(QObject):
 
     def close(self):
         self.algo_engine.shutdown()
+        self.animator_engine.shutdown()
         self.map.close()
 
     def create_village(self, name: str, 


### PR DESCRIPTION
## Summary
- hook up AnimatorEngine to NPC tick loop
- store AnimatorEngine on `World`
- call `NPC` tick callbacks from `AnimatorEngine`

## Testing
- `pytest -q byul_demo/wrapper/tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6870a00ef76083279da5f05a51382198